### PR TITLE
fix: clean up files

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "author": "Prismic <contact@prismic.io> (https://prismic.io)",
   "scripts": {
     "dev": "concurrently \"npm:next:dev\" \"npm:slicemachine\" --names \"next,slicemachine\" --prefix-colors blue,magenta",
+    "next:dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,3 +1,0 @@
-export default function Custom404() {
-  return <h1>404 - Page Not Found</h1>;
-}

--- a/pages/[uid].tsx
+++ b/pages/[uid].tsx
@@ -1,11 +1,11 @@
-import Head from 'next/head';
-import { SliceZone } from '@prismicio/react';
-import * as prismic from '@prismicio/client';
-import * as prismicH from '@prismicio/helpers';
-import type { InferGetStaticPropsType, GetStaticPropsContext } from 'next';
+import type { InferGetStaticPropsType, GetStaticPropsContext } from "next";
+import Head from "next/head";
+import * as prismic from "@prismicio/client";
+import * as prismicH from "@prismicio/helpers";
+import { SliceZone } from "@prismicio/react";
 
-import { createClient } from '../prismicio';
-import { components } from '../slices/';
+import { createClient } from "../prismicio";
+import { components } from "../slices";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 type PageParams = { uid: string };
@@ -31,7 +31,7 @@ export async function getStaticProps({
   const client = createClient({ previewData });
 
   if (params && params.uid) {
-    const page = await client.getByUID('page', params.uid);
+    const page = await client.getByUID("page", params.uid);
 
     if (page) {
       return {
@@ -43,10 +43,7 @@ export async function getStaticProps({
   }
 
   return {
-    redirect: {
-      permanent: false,
-      destination: '/404',
-    },
+    notFound: true,
   };
 }
 
@@ -56,8 +53,8 @@ export async function getStaticPaths() {
   /**
    * Query all Documents from the API, except the homepage.
    */
-  const pages = await client.getAllByType('page', {
-    predicates: [prismic.predicate.not('my.page.uid', 'home')],
+  const pages = await client.getAllByType("page", {
+    predicates: [prismic.predicate.not("my.page.uid", "home")],
   });
 
   /**

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,9 +1,9 @@
-import Link from 'next/link';
-import { PrismicProvider } from '@prismicio/react';
-import { PrismicPreview } from '@prismicio/next';
-import type { AppProps } from 'next/app';
+import type { AppProps } from "next/app";
+import Link from "next/link";
+import { PrismicProvider } from "@prismicio/react";
+import { PrismicPreview } from "@prismicio/next";
 
-import { repositoryName } from '../prismicio';
+import { repositoryName } from "../prismicio";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,16 +1,9 @@
-import { Html, Head, Main, NextScript } from 'next/document';
+import { Html, Head, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
     <Html lang="en">
-      <Head>
-        <link
-          rel="icon"
-          type="image/png"
-          sizes="any"
-          href="https://prismic.io/favicon.ico"
-        />
-      </Head>
+      <Head />
       <body>
         <Main />
         <NextScript />

--- a/pages/api/exit-preview.ts
+++ b/pages/api/exit-preview.ts
@@ -1,12 +1,12 @@
-import * as prismicNext from '@prismicio/next';
-import type { NextApiRequest, NextApiResponse } from 'next';
+import type { NextApiRequest, NextApiResponse } from "next";
+import * as prismicNext from "@prismicio/next";
 
 /**
  * This endpoint exits a preview session.
  */
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse
 ) {
   prismicNext.exitPreview({ res, req });
 }

--- a/pages/api/preview.ts
+++ b/pages/api/preview.ts
@@ -1,15 +1,14 @@
-import * as prismicNext from '@prismicio/next';
-import type { NextApiRequest, NextApiResponse } from 'next';
+import * as prismicNext from "@prismicio/next";
+import type { NextApiRequest, NextApiResponse } from "next";
 
-import { createClient } from '../../prismicio';
+import { createClient } from "../../prismicio";
 
 /**
- * This endpoint handles previews that are launched
- * from the Page Builder.
+ * This endpoint handles previews that are launched from the Page Builder.
  */
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse,
+  res: NextApiResponse
 ) {
   const client = createClient({ req });
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,10 @@
-import Head from 'next/head';
-import { SliceZone } from '@prismicio/react';
-import * as prismicH from '@prismicio/helpers';
-import type { InferGetStaticPropsType, GetStaticPropsContext } from 'next';
+import type { InferGetStaticPropsType, GetStaticPropsContext } from "next";
+import Head from "next/head";
+import * as prismicH from "@prismicio/helpers";
+import { SliceZone } from "@prismicio/react";
 
-import { createClient } from '../prismicio';
-import { components } from '../slices/';
+import { createClient } from "../prismicio";
+import { components } from "../slices/";
 
 type PageProps = InferGetStaticPropsType<typeof getStaticProps>;
 
@@ -32,7 +32,7 @@ export async function getStaticProps({ previewData }: GetStaticPropsContext) {
    */
   const client = createClient({ previewData });
 
-  const page = await client.getByUID('page', 'home');
+  const page = await client.getByUID("page", "home");
 
   return {
     props: {

--- a/pages/slice-simulator.tsx
+++ b/pages/slice-simulator.tsx
@@ -10,7 +10,8 @@ import { components } from "../slices";
 export default function SliceSimulatorPage() {
   return (
     <SliceSimulator
-      // The "sliceZone" prop should be a function receiving slices and rendering them using your "SliceZone" component.
+      // The "sliceZone" prop should be a function receiving Slices and
+      // rendering them using your "SliceZone" component.
       sliceZone={(props) => <SliceZone {...props} components={components} />}
       state={{}}
     />

--- a/prismicio.ts
+++ b/prismicio.ts
@@ -1,7 +1,7 @@
-import * as prismic from '@prismicio/client';
-import * as prismicNext from '@prismicio/next';
+import * as prismic from "@prismicio/client";
+import * as prismicNext from "@prismicio/next";
 
-import sm from './sm.json';
+import sm from "./sm.json";
 
 /**
  * The project's Prismic repository name.
@@ -10,18 +10,16 @@ export const repositoryName = prismic.getRepositoryName(sm.apiEndpoint);
 
 /**
  * The project's Prismic Route Resolvers. This list determines a Prismic document's URL.
- *
- * @type {prismic.ClientConfig['routes']}
  */
-const routes = [
+const routes: prismic.ClientConfig["routes"] = [
   {
-    type: 'page',
-    path: '/:uid',
+    type: "page",
+    path: "/:uid",
   },
   {
-    type: 'page',
-    uid: 'home',
-    path: '/',
+    type: "page",
+    uid: "home",
+    path: "/",
   },
 ];
 
@@ -29,7 +27,7 @@ const routes = [
  * Creates a Prismic client for the project's repository. The client is used to
  * query content from the Prismic API.
  *
- * @param config {prismicNext.CreateClientConfig} - Configuration for the Prismic client.
+ * @param config - Configuration for the Prismic client.
  */
 export const createClient = ({
   previewData,

--- a/slices/RichText/index.tsx
+++ b/slices/RichText/index.tsx
@@ -1,28 +1,21 @@
+import type { Content } from "@prismicio/client";
 import {
   PrismicRichText,
   SliceComponentProps,
   JSXMapSerializer,
-} from '@prismicio/react';
-// import type { Content } from '@prismicio/client';
-import type { Content } from '@prismicio/client';
-import type * as prismicH from '@prismicio/helpers';
-import styles from './index.module.css';
-
-export type RichTextProps = SliceComponentProps<Content.RichTextSlice>;
+} from "@prismicio/react";
+import styles from "./index.module.css";
 
 const components: JSXMapSerializer = {
   label: ({ node, children }) => {
-    if (node.data.label === 'codespan') {
+    if (node.data.label === "codespan") {
       return <code>{children}</code>;
     }
   },
 };
 
-/**
- * @typedef {import("@prismicio/client").Content.RichTextSlice} RichTextSlice
- * @typedef {import("@prismicio/react").SliceComponentProps<RichTextSlice>} RichTextProps
- * @param { RichTextProps }
- */
+type RichTextProps = SliceComponentProps<Content.RichTextSlice>;
+
 export default function RichText({ slice }: RichTextProps) {
   return (
     <section className={styles.richtext}>


### PR DESCRIPTION
This PR cleans up the starter in the following ways:

- Removes unused JSDoc comments. Future Slices will be created with JSDoc until we introduce Slice Machine plugins, but we are at least providing a correct example in `RichText/index.tsx`.
- Format files using default Prettier settings.
- Removes the 404 page. Next.js will use its default one instead, just like the default `create-next-app` setup.
- Update `_app.js` to be identical to `create-next-app`'s setup (notably removing the favicon).

I think everything should be good to go, but let me know your thoughts, especially on removing the favicon.

Thanks!
